### PR TITLE
Longest Common Substring & Smith-Waterman String Comparison A

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ ENV/
 
 # ASV 
 .asv/
+
+# PyCharm IDE
+.idea/

--- a/recordlinkage/algorithms/string.py
+++ b/recordlinkage/algorithms/string.py
@@ -1,4 +1,5 @@
 from __future__ import division
+from __future__ import unicode_literals
 
 import warnings
 

--- a/recordlinkage/algorithms/string.py
+++ b/recordlinkage/algorithms/string.py
@@ -207,7 +207,7 @@ def smith_waterman_similarity(s1, s2, match=5, mismatch=-5, gap_start=-5, gap_co
             # Initialize the score matrix
             m = [[0] * (1 + len(str2)) for i in range(1 + len(str1))]
             # Initialize the trace matrix the initial
-            t = [[[] for _ in range(1 + len(str2))] for _ in range(1 + len(str1))]
+            trace = [[[] for _ in range(1 + len(str2))] for _ in range(1 + len(str1))]
 
             highest = 0
 
@@ -218,12 +218,12 @@ def smith_waterman_similarity(s1, s2, match=5, mismatch=-5, gap_start=-5, gap_co
                     else:
                         diagonal = m[x-1][y-1] + mismatch
 
-                    if "L" in t[x-1][y]:
+                    if "L" in trace[x-1][y]:
                         gap_left = m[x-1][y] + gap_continue
                     else:
                         gap_left = m[x-1][y] + gap_start
 
-                    if "A" in t[x][y-1]:
+                    if "A" in trace[x][y-1]:
                         gap_above = m[x][y-1] + gap_continue
                     else:
                         gap_above = m[x][y-1] + gap_start
@@ -234,11 +234,11 @@ def smith_waterman_similarity(s1, s2, match=5, mismatch=-5, gap_start=-5, gap_co
                         score = 0
                     else:
                         if score == diagonal:
-                            t[x][y].append("D")
+                            trace[x][y].append("D")
                         if score == gap_above:
-                            t[x][y].append("A")
+                            trace[x][y].append("A")
                         if score == gap_left:
-                            t[x][y].append("L")
+                            trace[x][y].append("L")
 
                     if score > highest:
                         highest = score

--- a/recordlinkage/algorithms/string.py
+++ b/recordlinkage/algorithms/string.py
@@ -377,6 +377,9 @@ def longest_common_substring_similarity(s1, s2, norm='dice', min_len=2):
         adapted from
         https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Longest_common_substring.
         but oriented towards the iterative approach described by Christen, Peter (2012).
+
+        :param x: A tuple of strings for this step.
+        :return: A tuple of strings and a substring length i.e. ((str, str), int).
         """
 
         str1 = x[0]
@@ -387,26 +390,34 @@ def longest_common_substring_similarity(s1, s2, norm='dice', min_len=2):
             new_str1 = None
             new_str2 = None
         else:
-            # Creating a matrix of 0s
+            # Creating a matrix of 0s for preprocessing
             m = [[0] * (1 + len(str2)) for _ in range(1 + len(str1))]
 
+            # Track length of longest substring seen
             longest = 0
+
+            # Track the ending position of this substring in str1 (x) and str2(y)
             x_longest = 0
             y_longest = 0
 
+            # Create matrix of substring lengths
             for x in range(1, 1 + len(str1)):
                 for y in range(1, 1 + len(str2)):
                     # Check if the chars match
                     if str1[x - 1] == str2[y - 1]:
                         # add 1 to the diagnol
                         m[x][y] = m[x - 1][y - 1] + 1
+                        # Update values if longer than previous longest substring
                         if m[x][y] > longest:
                             longest = m[x][y]
                             x_longest = x
                             y_longest = y
                     else:
+                        # If there is no match, start from zero
                         m[x][y] = 0
 
+            # Copy str1 and str2, but substracting the longest common substring
+            # for the next iteration.
             new_str1 = str1[0:x_longest-longest]+str1[x_longest:]
             new_str2 = str2[0:y_longest-longest]+str2[y_longest:]
 
@@ -420,28 +431,41 @@ def longest_common_substring_similarity(s1, s2, norm='dice', min_len=2):
         # Compute lcs value with first ordering.
         lcs_acc_1 = 0
         new_x_1 = (x[0], x[1])
-
         while True:
+            # Get new string pair (iter_x) and length (iter_lcs)
+            # for this iteration.
             iter_x, iter_lcs = lcs_iteration(new_x_1)
             if iter_lcs < min_len:
+                # End if the longest substring is below the threshold
                 break
             else:
+                # Otherwise, accumulate length and start a new iteration
+                # with the new string pair.
                 new_x_1 = iter_x
                 lcs_acc_1 = lcs_acc_1 + iter_lcs
 
         # Compute lcs value with second ordering.
         lcs_acc_2 = 0
         new_x_2 = (x[1], x[0])
-
         while True:
+            # Get new string pair (iter_x) and length (iter_lcs)
+            # for this iteration.
             iter_x, iter_lcs = lcs_iteration(new_x_2)
             if iter_lcs < min_len:
+                # End if the longest substring is below the threshold
                 break
             else:
+                # Otherwise, accumulate length and start a new iteration
+                # with the new string pair.
                 new_x_2 = iter_x
                 lcs_acc_2 = lcs_acc_2 + iter_lcs
 
         def normalize_lcs(lcs_value):
+            """
+            Apply one of the normalization schemes described in in Christen, Peter (2012).
+            :param float lcs_value: The raw lcs length.
+            :return: The normalized lcs length.
+            """
             if norm == 'overlap':
                 return lcs_value / min(len(x[0]), len(x[1]))
             elif norm == 'jaccard':
@@ -452,7 +476,7 @@ def longest_common_substring_similarity(s1, s2, norm='dice', min_len=2):
                 warnings.warn('Unrecognized longest common substring normalization. Defaulting to "dice" method.')
                 return lcs_value*2 / (len(x[0])+len(x[1]))
 
-        # Average the two orderings.
+        # Average the two orderings, since lcs may be sensitive to comparison order.
         return (normalize_lcs(lcs_acc_1)+normalize_lcs(lcs_acc_2)) / 2
 
     return conc.apply(lcs_apply, axis=1)

--- a/recordlinkage/algorithms/string.py
+++ b/recordlinkage/algorithms/string.py
@@ -186,7 +186,7 @@ def smith_waterman(s1, s2, match=5, mismatch=-5, gap_start=-5, gap_continue=-1, 
         A pandas series with similarity values. Values equal or between 0
         and 1.
     """
-    # Assert that match is greater than or equal to mismatch, gap_start, and gap_conntinue.
+    # Assert that match is greater than or equal to mismatch, gap_start, and gap_continue.
     assert match >= max(mismatch, gap_start, gap_continue), \
         "match must be greater than or equal to mismatch, gap_start, and gap_continue"
 
@@ -257,7 +257,7 @@ def smith_waterman(s1, s2, match=5, mismatch=-5, gap_start=-5, gap_continue=-1, 
             return normalize(compute_score())
         except Exception as err:
             if pandas.isnull(t[0]) or pandas.isnull(t[1]):
-                return np.nan
+                return 0
             else:
                 raise err
 

--- a/recordlinkage/algorithms/string.py
+++ b/recordlinkage/algorithms/string.py
@@ -147,3 +147,9 @@ def cosine_similarity(s1, s2, include_wb=True, ngram=(2, 2)):
         return np.divide(ab, np.multiply(a, b)).A1
 
     return _metric_sparse_cosine(vec_fit[:len(s1)], vec_fit[len(s1):])
+
+def smith_waterman(s1, s2, match=1, mismatch=1, gap=1):
+    return 0
+
+def lcs(s1, s2):
+    return 0

--- a/recordlinkage/algorithms/string.py
+++ b/recordlinkage/algorithms/string.py
@@ -200,65 +200,148 @@ def smith_waterman_similarity(s1, s2, match=5, mismatch=-5, gap_start=-5, gap_co
     concat = pandas.concat([s1, s2], axis=1, ignore_index=True)
 
     def sw_apply(t):
+        """
+        sw_apply()
+
+        A helper function that is applied to each pair of records
+        in s1 and s2. Assigns a similarity score to each pair,
+        between 0 and 1. Used by the pandas.apply method.
+
+        Parameters
+        ----------
+        t : pandas.Series
+            A pandas Series containing two strings to be compared.
+
+        Returns
+        -------
+        Float
+            A similarity score between 0 and 1.
+        """
+        print(t)
+        print(type(t))
         str1 = t[0]
         str2 = t[1]
 
         def compute_score():
-            # Initialize the score matrix
+            """
+            compute_score()
+
+            The helper function that produces the non-normalized
+            similarity score between two strings. The scores are
+            determined using the Smith-Waterman dynamic programming
+            algorithm. The scoring scheme is determined from the
+            parameters provided to the parent smith_waterman_similarity()
+            function.
+
+            Returns
+            -------
+            Float
+                A score 0 or greater. Indicates similarity between two strings.
+            """
+
+            # Initialize the score matrix with 0s
+
             m = [[0] * (1 + len(str2)) for i in range(1 + len(str1))]
-            # Initialize the trace matrix the initial
+
+            # Initialize the trace matrix with empty lists
             trace = [[[] for _ in range(1 + len(str2))] for _ in range(1 + len(str1))]
 
+            # Initialize the highest seen score to 0
             highest = 0
 
+            # Iterate through the matrix
             for x in range(1, 1 + len(str1)):
                 for y in range(1, 1 + len(str2)):
+                    # Calculate Diagonal Score
                     if str1[x-1] == str2[y-1]:
+                        # If characters match, add the match score to the diagonal score
                         diagonal = m[x-1][y-1] + match
                     else:
+                        # If characters do not match, add the mismatch score to the diagonal score
                         diagonal = m[x-1][y-1] + mismatch
 
-                    if "L" in trace[x-1][y]:
-                        gap_left = m[x-1][y] + gap_continue
+                    # Calculate the Left Gap Score
+                    if "H" in trace[x-1][y]:
+                        # If cell to the left's score was calculated based on a horizontal gap,
+                        # add the gap continuation penalty to the left score.
+                        gap_horizontal = m[x-1][y] + gap_continue
                     else:
-                        gap_left = m[x-1][y] + gap_start
+                        # Otherwise, add the gap start penalty to the left score
+                        gap_horizontal = m[x-1][y] + gap_start
 
-                    if "A" in trace[x][y-1]:
-                        gap_above = m[x][y-1] + gap_continue
+                    # Calculate the Above Gap Score
+                    if "V" in trace[x][y-1]:
+                        # If above cell's score was calculated based on a vertical gap,
+                        # add the gap continuation penalty to the above score.
+                        gap_vertical = m[x][y-1] + gap_continue
                     else:
-                        gap_above = m[x][y-1] + gap_start
+                        # Otherwise, add the gap start penalty to the above score
+                        gap_vertical = m[x][y-1] + gap_start
 
-                    score = max(diagonal, gap_left, gap_above)
+                    # Choose the highest of the three scores
+                    score = max(diagonal, gap_horizontal, gap_vertical)
 
                     if score <= 0:
+                        # If score is less than 0, boost to 0
                         score = 0
                     else:
+                        # If score is greater than 0, determine whether it was
+                        # calculated based on a diagonal score, horizontal gap,
+                        # or vertical gap. Store D, H, or V in the trace matrix
+                        # accordingly.
                         if score == diagonal:
                             trace[x][y].append("D")
-                        if score == gap_above:
-                            trace[x][y].append("A")
-                        if score == gap_left:
-                            trace[x][y].append("L")
+                        if score == gap_horizontal:
+                            trace[x][y].append("H")
+                        if score == gap_vertical:
+                            trace[x][y].append("V")
 
+                    # If the cell's score is greater than the highest score
+                    # previously present, record the score as the highest.
                     if score > highest:
                         highest = score
 
+                    # Set the cell's score to score
                     m[x][y] = score
 
+            # After iterating through the entire matrix, return the highest
+            # score found.
             return highest
 
         def normalize(score):
+            """
+            normalize(score)
+
+            A helper function used to normalize the score produced by
+            compute_score() to a score between 0 and 1. The method for
+            normalization is determined by the norm argument provided
+            to the parent, smith_waterman_similarity function.
+
+            Parameters
+            ----------
+            score : Float
+                The score produced by the compute_score() function.
+
+            Returns
+            -------
+            Float
+                A normalized score between 0 and 1.
+            """
             if norm == "min":
+                # Normalize by the shorter string's length
                 return score/(min(len(str1), len(str2)) * match)
             if norm == "max":
+                # Normalize by the longer string's length
                 return score/(max(len(str1), len(str2)) * match)
             if norm == "mean":
+                # Normalize by the mean length of the two strings
                 return 2*score/((len(str1) + len(str2)) * match)
 
         try:
             if len(str1) == 0 or len(str2) == 0:
                 return 0
             return normalize(compute_score())
+
         except Exception as err:
             if pandas.isnull(t[0]) or pandas.isnull(t[1]):
                 return np.nan

--- a/recordlinkage/algorithms/string.py
+++ b/recordlinkage/algorithms/string.py
@@ -257,7 +257,7 @@ def smith_waterman(s1, s2, match=5, mismatch=-5, gap_start=-5, gap_continue=-1, 
             return normalize(compute_score())
         except Exception as err:
             if pandas.isnull(t[0]) or pandas.isnull(t[1]):
-                return 0
+                return np.nan
             else:
                 raise err
 

--- a/recordlinkage/algorithms/string.py
+++ b/recordlinkage/algorithms/string.py
@@ -194,6 +194,9 @@ def smith_waterman_similarity(s1, s2, match=5, mismatch=-5, gap_start=-5, gap_co
     if len(s1) != len(s2):
         raise ValueError('Arrays or Series have to be same length.')
 
+    if len(s1) == len(s2) == 0:
+        return []
+
     concat = pandas.concat([s1, s2], axis=1, ignore_index=True)
 
     def sw_apply(t):

--- a/recordlinkage/algorithms/string.py
+++ b/recordlinkage/algorithms/string.py
@@ -241,15 +241,6 @@ def smith_waterman(s1, s2, match=5, mismatch=-5, gap_start=-5, gap_continue=-1, 
 
                     m[x][y] = score
 
-            df = pandas.DataFrame(t)
-            print(df)
-            for r in m:
-                print(r)
-            print("*******************")
-            for r in t:
-                print(r)
-            print("===================")
-            print(highest)
             return highest
 
         def normalize(score):

--- a/recordlinkage/algorithms/string.py
+++ b/recordlinkage/algorithms/string.py
@@ -186,6 +186,12 @@ def smith_waterman(s1, s2, match=1, mismatch=-1, gap_start=-1, gap_continue=-0.2
         A pandas series with similarity values. Values equal or between 0
         and 1.
     """
+    # Assert that match is greater than or equal to mismatch, gap_start, and gap_conntinue.
+    assert match >= max(mismatch, gap_start, gap_continue), "match must greater than or equal to mismatch, gap_start, and gap_continue"
+
+    if len(s1) != len(s2):
+        raise ValueError('Arrays or Series have to be same length.')
+
     concat = pandas.concat([s1, s2], axis=1, ignore_index=True)
 
     def sw_apply(t):
@@ -235,7 +241,6 @@ def smith_waterman(s1, s2, match=1, mismatch=-1, gap_start=-1, gap_continue=-0.2
         try:
             if len(str1) == 0 or len(str2) == 0:
                 return 0
-
             return normalize(compute_score())
         except Exception as err:
             if pandas.isnull(t[0]) or pandas.isnull(t[1]):

--- a/recordlinkage/algorithms/string.py
+++ b/recordlinkage/algorithms/string.py
@@ -149,11 +149,12 @@ def cosine_similarity(s1, s2, include_wb=True, ngram=(2, 2)):
     return _metric_sparse_cosine(vec_fit[:len(s1)], vec_fit[len(s1):])
 
 
-def smith_waterman(s1, s2, match=5, mismatch=-5, gap_start=-5, gap_continue=-1, norm="mean"):
+def smith_waterman_similarity(s1, s2, match=5, mismatch=-5, gap_start=-5, gap_continue=-1, norm="mean"):
     """
     string(s1, s2, match=1, mismatch=-1, gap_start=-1, gap_continue=-0.2, norm="mean")
 
-    An implementation of the Smith-Waterman string comparison algorithm.
+    An implementation of the Smith-Waterman string comparison algorithm
+    described in Christen, Peter (2012).
 
     Parameters
     ----------
@@ -262,3 +263,110 @@ def smith_waterman(s1, s2, match=5, mismatch=-5, gap_start=-5, gap_continue=-1, 
                 raise err
 
     return concat.apply(sw_apply, axis=1)
+
+
+def longest_common_substring_similarity(s1, s2, norm='dice', min_len=2):
+    """
+    An implementation of the longest common substring similarity algorithm
+    described in Christen, Peter (2012).
+
+    :param pd.Series s1: Comparison data.
+    :param pd.Series s2: Comparison data.
+    :param str norm: The normalization applied to the raw length computed by the lcs algorithm.
+    :param int min_len: The minimum length of substring to be considered.
+    :return: A pd.Series of normalized similarity values.
+    """
+
+    if len(s1) != len(s2):
+        raise ValueError('Arrays or Series have to be same length.')
+
+    if len(s1) == len(s2) == 0:
+        return []
+
+    conc = pandas.concat([s1, s2], axis=1, ignore_index=True)
+
+    def lcs_iteration(x):
+        """
+        A helper function implementation of a single iteration longest common substring algorithm,
+        adapted from
+        https://en.wikibooks.org/wiki/Algorithm_Implementation/Strings/Longest_common_substring.
+        but oriented towards the iterative approach described by Christen, Peter (2012).
+        """
+
+        str1 = x[0]
+        str2 = x[1]
+
+        if str1 is np.nan or str2 is np.nan or min(len(str1), len(str2)) < min_len:
+            longest = 0
+            new_str1 = None
+            new_str2 = None
+        else:
+            # Creating a matrix of 0s
+            m = [[0] * (1 + len(str2)) for _ in range(1 + len(str1))]
+
+            longest = 0
+            x_longest = 0
+            y_longest = 0
+
+            for x in range(1, 1 + len(str1)):
+                for y in range(1, 1 + len(str2)):
+                    # Check if the chars match
+                    if str1[x - 1] == str2[y - 1]:
+                        # add 1 to the diagnol
+                        m[x][y] = m[x - 1][y - 1] + 1
+                        if m[x][y] > longest:
+                            longest = m[x][y]
+                            x_longest = x
+                            y_longest = y
+                    else:
+                        m[x][y] = 0
+
+            new_str1 = str1[0:x_longest-longest]+str1[x_longest:]
+            new_str2 = str2[0:y_longest-longest]+str2[y_longest:]
+
+        return (new_str1, new_str2), longest
+
+    def lcs_apply(x):
+
+        if pandas.isnull(x[0]) or pandas.isnull(x[1]):
+            return np.nan
+
+        # Compute lcs value with first ordering.
+        lcs_acc_1 = 0
+        new_x_1 = (x[0], x[1])
+
+        while True:
+            iter_x, iter_lcs = lcs_iteration(new_x_1)
+            if iter_lcs < min_len:
+                break
+            else:
+                new_x_1 = iter_x
+                lcs_acc_1 = lcs_acc_1 + iter_lcs
+
+        # Compute lcs value with second ordering.
+        lcs_acc_2 = 0
+        new_x_2 = (x[1], x[0])
+
+        while True:
+            iter_x, iter_lcs = lcs_iteration(new_x_2)
+            if iter_lcs < min_len:
+                break
+            else:
+                new_x_2 = iter_x
+                lcs_acc_2 = lcs_acc_2 + iter_lcs
+
+        def normalize_lcs(lcs_value):
+            if norm == 'overlap':
+                return lcs_value / min(len(x[0]), len(x[1]))
+            elif norm == 'jaccard':
+                return lcs_value / (len(x[0])+len(x[1])-abs(lcs_value))
+            elif norm == 'dice':
+                return lcs_value*2 / (len(x[0])+len(x[1]))
+            else:
+                warnings.warn('Unrecognized longest common substring normalization. Defaulting to "dice" method.')
+                return lcs_value*2 / (len(x[0])+len(x[1]))
+
+        # Average the two orderings.
+        return (normalize_lcs(lcs_acc_1)+normalize_lcs(lcs_acc_2)) / 2
+
+    return conc.apply(lcs_apply, axis=1)

--- a/recordlinkage/comparing.py
+++ b/recordlinkage/comparing.py
@@ -23,7 +23,8 @@ from recordlinkage.algorithms.string import (jaro_similarity,
                                              levenshtein_similarity,
                                              damerau_levenshtein_similarity,
                                              qgram_similarity,
-                                             cosine_similarity)
+                                             cosine_similarity,
+                                             smith_waterman)
 
 
 def fillna_decorator(missing_value=np.nan):
@@ -471,7 +472,7 @@ class Compare(CompareCore):
         method : str
             A approximate string comparison method. Options are ['jaro',
             'jarowinkler', 'levenshtein', 'damerau_levenshtein', 'qgram',
-            'cosine']. Default: 'levenshtein'
+            'cosine', smith_waterman]. Default: 'levenshtein'
         threshold : float, tuple of floats
             A threshold value. All approximate string comparisons higher or
             equal than this threshold are 1. Otherwise 0.
@@ -515,6 +516,8 @@ class Compare(CompareCore):
             elif method == 'cosine':
                 str_sim_alg = cosine_similarity
 
+            elif method == 'smith_waterman' or method == "smithwaterman":
+                str_sim_alg = smith_waterman
             else:
                 raise ValueError("The algorithm '{}' is not known.".format(method))
 

--- a/recordlinkage/comparing.py
+++ b/recordlinkage/comparing.py
@@ -24,7 +24,8 @@ from recordlinkage.algorithms.string import (jaro_similarity,
                                              damerau_levenshtein_similarity,
                                              qgram_similarity,
                                              cosine_similarity,
-                                             smith_waterman)
+                                             smith_waterman_similarity,
+                                             longest_common_substring_similarity)
 
 
 def fillna_decorator(missing_value=np.nan):
@@ -472,7 +473,7 @@ class Compare(CompareCore):
         method : str
             A approximate string comparison method. Options are ['jaro',
             'jarowinkler', 'levenshtein', 'damerau_levenshtein', 'qgram',
-            'cosine', smith_waterman]. Default: 'levenshtein'
+            'cosine', 'smith_waterman', 'lcs']. Default: 'levenshtein'
         threshold : float, tuple of floats
             A threshold value. All approximate string comparisons higher or
             equal than this threshold are 1. Otherwise 0.
@@ -517,7 +518,11 @@ class Compare(CompareCore):
                 str_sim_alg = cosine_similarity
 
             elif method == 'smith_waterman' or method == "smithwaterman":
-                str_sim_alg = smith_waterman
+                str_sim_alg = smith_waterman_similarity
+
+            elif method == 'lcs':
+                str_sim_alg = longest_common_substring_similarity
+
             else:
                 raise ValueError("The algorithm '{}' is not known.".format(method))
 

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -26,6 +26,9 @@ COMPARE_ALGORITHMS = [
     param('string', 'given_name', 'given_name', method='damerau_levenshtein'),
     param('string', 'given_name', 'given_name', method='qgram'),
     param('string', 'given_name', 'given_name', method='cosine'),
+    param('string', 'given_name', 'given_name', method='lcs', norm='dice'),
+    param('string', 'given_name', 'given_name', method='lcs', norm='jaccard'),
+    param('string', 'given_name', 'given_name', method='lcs', norm='overlap'),
 
     # numeric
     param('numeric', 'age', 'age', method='step',

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -11,7 +11,7 @@ import pandas
 
 STRING_SIM_ALGORITHMS = [
     'jaro', 'q_gram', 'cosine', 'jaro_winkler', 'dameraulevenshtein',
-    'levenshtein'
+    'levenshtein', 'lcs', 'smith_waterman'
 ]
 
 NUMERIC_SIM_ALGORITHMS = [
@@ -29,6 +29,9 @@ COMPARE_ALGORITHMS = [
     param('string', 'given_name', 'given_name', method='lcs', norm='dice'),
     param('string', 'given_name', 'given_name', method='lcs', norm='jaccard'),
     param('string', 'given_name', 'given_name', method='lcs', norm='overlap'),
+    param('string', 'given_name', 'given_name', method='smith_waterman', norm='min'),
+    param('string', 'given_name', 'given_name', method='smith_waterman', norm='max'),
+    param('string', 'given_name', 'given_name', method='smith_waterman', norm='mean'),
 
     # numeric
     param('numeric', 'age', 'age', method='step',

--- a/tests/test_compare_algorithms.py
+++ b/tests/test_compare_algorithms.py
@@ -614,6 +614,9 @@ class TestCompareAlgorithms(unittest.TestCase):
             ['Anne'],
             ['Elizabeth'],
             ['Sarah'],
+            ['University of Waterloo'],
+            ['tyler'],
+            ['Betty']
         ],
             columns=['str_1'])
         self.E.index.name = 'index_df5'
@@ -629,6 +632,9 @@ class TestCompareAlgorithms(unittest.TestCase):
             ['Jill'],
             ['Elisabeth'],
             ['Sarrrrah'],
+            ['University Waterloo'],
+            ['Betty'],
+            ['tyler']
         ],
             columns=['str_2'])
         self.F.index.name = 'index_df6'
@@ -646,13 +652,13 @@ class TestCompareAlgorithms(unittest.TestCase):
         comp.string('str_1', 'str_2', method='smith_waterman', norm='max', gap_continue=-5, name='max_2')
         comp.string('str_1', 'str_2', method='smith_waterman', norm='mean', gap_continue=-5, name='mean_2')
 
-        expected_min_1 = pandas.Series([0, 0, 0, 0, 0, 0, 1, 0, 7/9, 3.6/5])
-        expected_max_1 = pandas.Series([0, 0, 0, 0, 0, 0, 1, 0, 7/9, 3.6/8])
-        expected_mean_1 = pandas.Series([0, 0, 0, 0, 0, 0, 1, 0, 7/9, 3.6/6.5])
+        expected_min_1 = pandas.Series([0, 0, 0, 0, 0, 0, 1, 0, 7/9, 3.6/5, 17.6/19, 2/5, 2/5])
+        expected_max_1 = pandas.Series([0, 0, 0, 0, 0, 0, 1, 0, 7/9, 3.6/8, 17.6/22, 2/5, 2/5])
+        expected_mean_1 = pandas.Series([0, 0, 0, 0, 0, 0, 1, 0, 7/9, 3.6/6.5, 17.6/20.5, 2/5, 2/5])
 
-        expected_min_2 = pandas.Series([0, 0, 0, 0, 0, 0, 1, 0, 7/9, 3/5])
-        expected_max_2 = pandas.Series([0, 0, 0, 0, 0, 0, 1, 0, 7/9, 3/8])
-        expected_mean_2 = pandas.Series([0, 0, 0, 0, 0, 0, 1, 0, 7/9, 3/6.5])
+        expected_min_2 = pandas.Series([0, 0, 0, 0, 0, 0, 1, 0, 7/9, 3/5, 16/19, 2/5, 2/5])
+        expected_max_2 = pandas.Series([0, 0, 0, 0, 0, 0, 1, 0, 7/9, 3/8, 16/22, 2/5, 2/5])
+        expected_mean_2 = pandas.Series([0, 0, 0, 0, 0, 0, 1, 0, 7/9, 3/6.5, 16/20.5, 2/5, 2/5])
 
         SW_TEST_CASES = [
             (comp.vectors['min_1'], expected_min_1, 'min_1'),

--- a/tests/test_compare_algorithms.py
+++ b/tests/test_compare_algorithms.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals
+# -*- coding: utf-8 -*-
 
 import unittest
 

--- a/tests/test_compare_algorithms.py
+++ b/tests/test_compare_algorithms.py
@@ -680,22 +680,22 @@ class TestCompareAlgorithms(unittest.TestCase):
     def test_lcs_correctness(self):
 
         self.C = pandas.DataFrame([
-            ['peter christen'],
-            ['peter christen'],
-            ['prap'],
-            ['résumé'],
-            ['aba'],
+            [u'peter christen'],
+            [u'peter christen'],
+            [u'prap'],
+            [u'résumé'],
+            [u'aba'],
         ],
             columns=['str_1'])
 
         self.C.index.name = 'index_df3'
 
         self.D = pandas.DataFrame([
-            ['christian pedro'],
-            ['christen peter'],
-            ['papr'],
-            ['resume'],
-            ['abbaba']
+            [u'christian pedro'],
+            [u'christen peter'],
+            [u'papr'],
+            [u'resume'],
+            [u'abbaba']
         ],
             columns=['str_2'])
 

--- a/tests/test_compare_algorithms.py
+++ b/tests/test_compare_algorithms.py
@@ -734,4 +734,7 @@ class TestCompareAlgorithms(unittest.TestCase):
         for tup in LCS_TEST_CASES:
             assert(len(tup[0]) == len(tup[1]))
             for i in range(0, len(tup[0])):
-                self.assertAlmostEqual(tup[0].iloc[i], tup[1].iloc[i], places=3, msg='Failed on test {} number {}'.format(tup[2], i))
+                self.assertAlmostEqual(tup[0].iloc[i], tup[1].iloc[i], places=3,
+                                       msg='Failed on test {} number {} ({} != {})'.format(
+                                           tup[2], i, tup[0].iloc[i], tup[1].iloc[i])
+                                       )

--- a/tests/test_compare_algorithms.py
+++ b/tests/test_compare_algorithms.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import unittest
 
 import pandas.util.testing as pdt

--- a/tests/test_compare_algorithms.py
+++ b/tests/test_compare_algorithms.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from __future__ import division
 
 import unittest
 


### PR DESCRIPTION
This pull request implements two new string comparison algorithms, longest common substring and Smith-Waterman, to the `Compare.string()` method.

Both comparison algorithms have been implemented as described by Peter Christen in sections 5.3.1 and 5.9 his book _Data Matching_. We have found each of these string comparison algorithms to be extremely useful in our own record linkage workflows, especially when dealing with unstructured text.

@joelbecker and @jillianderson8 are the @networks-lab developers who contributed to these features. To ensure their contributions are recognized, we would appreciate it if you did not squash their commits if/when you merge this pull request.