### PR TITLE
Improvements to string comparison efficiency.

### DIFF
--- a/recordlinkage/algorithms/string.py
+++ b/recordlinkage/algorithms/string.py
@@ -20,7 +20,7 @@ warnings.filterwarnings("ignore")
 
 def jaro_similarity(s1, s2):
 
-    conc = pandas.concat([s1, s2], axis=1, ignore_index=True)
+    conc = pandas.Series(list(zip(s1, s2)))
 
     def jaro_apply(x):
 
@@ -32,15 +32,14 @@ def jaro_similarity(s1, s2):
             else:
                 raise err
 
-    return conc.apply(jaro_apply, axis=1)
+    return conc.apply(jaro_apply)
 
 
 def jarowinkler_similarity(s1, s2):
 
-    conc = pandas.concat([s1, s2], axis=1, ignore_index=True)
+    conc = pandas.Series(list(zip(s1, s2)))
 
     def jaro_winkler_apply(x):
-
         try:
             return jellyfish.jaro_winkler(x[0], x[1])
         except Exception as err:
@@ -49,12 +48,12 @@ def jarowinkler_similarity(s1, s2):
             else:
                 raise err
 
-    return conc.apply(jaro_winkler_apply, axis=1)
+    return conc.apply(jaro_winkler_apply)
 
 
 def levenshtein_similarity(s1, s2):
 
-    conc = pandas.concat([s1, s2], axis=1, ignore_index=True)
+    conc = pandas.Series(list(zip(s1, s2)))
 
     def levenshtein_apply(x):
 
@@ -67,12 +66,12 @@ def levenshtein_similarity(s1, s2):
             else:
                 raise err
 
-    return conc.apply(levenshtein_apply, axis=1)
+    return conc.apply(levenshtein_apply)
 
 
 def damerau_levenshtein_similarity(s1, s2):
 
-    conc = pandas.concat([s1, s2], axis=1, ignore_index=True)
+    conc = pandas.Series(list(zip(s1, s2)))
 
     def damerau_levenshtein_apply(x):
 
@@ -85,7 +84,7 @@ def damerau_levenshtein_similarity(s1, s2):
             else:
                 raise err
 
-    return conc.apply(damerau_levenshtein_apply, axis=1)
+    return conc.apply(damerau_levenshtein_apply)
 
 
 def qgram_similarity(s1, s2, include_wb=True, ngram=(2, 2)):
@@ -198,7 +197,7 @@ def smith_waterman_similarity(s1, s2, match=5, mismatch=-5, gap_start=-5, gap_co
     if len(s1) == len(s2) == 0:
         return []
 
-    concat = pandas.concat([s1, s2], axis=1, ignore_index=True)
+    concat = pandas.Series(list(zip(s1, s2)))
 
     def sw_apply(t):
         """
@@ -218,8 +217,6 @@ def smith_waterman_similarity(s1, s2, match=5, mismatch=-5, gap_start=-5, gap_co
         Float
             A similarity score between 0 and 1.
         """
-        print(t)
-        print(type(t))
         str1 = t[0]
         str2 = t[1]
 
@@ -351,7 +348,7 @@ def smith_waterman_similarity(s1, s2, match=5, mismatch=-5, gap_start=-5, gap_co
             else:
                 raise err
 
-    return concat.apply(sw_apply, axis=1)
+    return concat.apply(sw_apply)
 
 
 def longest_common_substring_similarity(s1, s2, norm='dice', min_len=2):
@@ -384,7 +381,7 @@ def longest_common_substring_similarity(s1, s2, norm='dice', min_len=2):
     if len(s1) == len(s2) == 0:
         return []
 
-    conc = pandas.concat([s1, s2], axis=1, ignore_index=True)
+    conc = pandas.Series(list(zip(s1, s2)))
 
     def lcs_iteration(x):
         """
@@ -531,4 +528,4 @@ def longest_common_substring_similarity(s1, s2, norm='dice', min_len=2):
         # Average the two orderings, since lcs may be sensitive to comparison order.
         return (normalize_lcs(lcs_acc_1)+normalize_lcs(lcs_acc_2)) / 2
 
-    return conc.apply(lcs_apply, axis=1)
+    return conc.apply(lcs_apply)

--- a/recordlinkage/comparing.py
+++ b/recordlinkage/comparing.py
@@ -346,6 +346,7 @@ class CompareCore(object):
             name_or_id = name if name else len(self.vectors.columns)
             self.vectors[name_or_id] = c
 
+        # TODO: Encountered error when store = False (2017-07-27)
         return self.vectors[name_or_id].rename(name)
 
     def run(self):


### PR DESCRIPTION
This pull request changes the data structures used within the `recordlinkage` string comparison algorithms. Instead of concatenating two series into a `pandas.DataFrame` and applying a function to its rows, these algorithms now apply the same function to a `pandas.Series` of tuples. These changes were minimally invasive, but appear to drastically improve efficiency for some algorithms. 

The table below show the results of an informal performance experiment run on my 2012 Macbook Pro (Intel(R) Core(TM) i7-3615QM CPU @ 2.30GHz; 16GB RAM). Each comparison algorithm was applied to a set of ~ 200,000 candidate links with the original algorithms and the modified algorithms. Each trial was repeated five times, with very little variance between replications. Results show significant performance increases in all string comparison methods that were modified (note that `qgram` and `cosine` similarities were not changed and were therefore not assessed).

This table shows the mean time in seconds (i.e. the average observed across five trials) to compare 200,000 candidate links with the original and modified algorithms:

<center>
<table>
<thead>
<tr><th style="text-align: right;">  </th><th>Metric            </th><th>Trial   </th><th style="text-align: right;">  Mean (seconds)</th></tr>
</thead>
<tbody>
<tr><td style="text-align: right;"> 1</td><td>dameraulevenshtein</td><td>new     </td><td style="text-align: right;">        4.35562 </td></tr>
<tr><td style="text-align: right;"> 2</td><td>dameraulevenshtein</td><td>original</td><td style="text-align: right;">       43.4045  </td></tr>
<tr><td style="text-align: right;"> 3</td><td>jaro              </td><td>new     </td><td style="text-align: right;">        0.334586</td></tr>
<tr><td style="text-align: right;"> 4</td><td>jaro              </td><td>original</td><td style="text-align: right;">       29.488   </td></tr>
<tr><td style="text-align: right;">5</td><td>jaro_winkler      </td><td>new     </td><td style="text-align: right;">        0.315651</td></tr>
<tr><td style="text-align: right;"> 6</td><td>jaro_winkler      </td><td>original</td><td style="text-align: right;">       30.9617  </td></tr>
<tr><td style="text-align: right;"> 7</td><td>lcs               </td><td>new     </td><td style="text-align: right;">       14.0373  </td></tr>
<tr><td style="text-align: right;">8</td><td>lcs               </td><td>original</td><td style="text-align: right;">       71.3062  </td></tr>
<tr><td style="text-align: right;">9</td><td>levenshtein       </td><td>new     </td><td style="text-align: right;">        4.09868 </td></tr>
<tr><td style="text-align: right;">10</td><td>levenshtein       </td><td>original</td><td style="text-align: right;">       42.8332  </td></tr>
<tr><td style="text-align: right;">11</td><td>smith_waterman    </td><td>new     </td><td style="text-align: right;">       23.0192  </td></tr>
<tr><td style="text-align: right;">12</td><td>smith_waterman    </td><td>original</td><td style="text-align: right;">       47.7344  </td></tr>
</tbody>
</table>
</center>

Note that due to technical problems, I was unable to run formal benchmarks using `asv` on my own machine. @J535D165, if these changes are merged, it would be good to get a more formal / comparable benchmark using `asv` on whatever machine you use for benchmarking.