### PR TITLE
modified to use the missing_values argument value in the output

### DIFF
--- a/recordlinkage/compare.py
+++ b/recordlinkage/compare.py
@@ -153,7 +153,8 @@ class String(BaseCompareFeature):
         c = _fillna(c, self.missing_value)
 
         if self.threshold is not None:
-            return (c >= self.threshold).astype(numpy.float64)
+            return c.where(c >= self.threshold, other=0.0)
+            # return (c >= self.threshold).astype(numpy.float64)
         else:
             return c
 


### PR DESCRIPTION
This is a very minor change that I made for my purposes. When performing string comparisons, if a missing_values argument is provided in addition to the threshold argument, the missing_values value will not appear in the output because the threshold code returns True or False (is then converted to 0.0 and 1.0). I believe this is a mistake because it make it impossible to delineate between pairs that did not match and pairs that contained a missing value.

Hope this helps!
Kai Wombacher