### PR TITLE
Drop support for Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
 dist: xenial
 
 python:
-  - "2.7"
   - "3.5"
   - "3.6"
 

--- a/README.rst
+++ b/README.rst
@@ -136,11 +136,15 @@ share, let us know.
 Dependencies, installation and license
 --------------------------------------
 
-Install the Python Record Linkage Toolkit easily with pip
+The Python Record linkage Toolkit requires Python 3.5 or higher (since version
+>= 0.14). Install the package easily with pip
 
 .. code:: sh
 
     pip install recordlinkage
+
+Python 2.7 users can use version <= 0.13, but it is advised to use Python >=
+3.5.
 
 The toolkit depends on Pandas_ (>=18.0), Numpy_, `Scikit-learn`_, Scipy_ and
 Jellyfish_. You probably have most of them already installed. The package

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,12 +14,15 @@ documentation_.
 Installation
 ============
 
-The easiest way of installing the Python Record Linkage Toolkit is using
-``pip``. It is as easy as typing:
+The Python Record linkage Toolkit requires Python 3.5 or higher (since version
+>= 0.14). Install the package easily with pip
 
 .. code:: sh
 
-	pip install --user recordlinkage
+    pip install recordlinkage
+
+Python 2.7 users can use version <= 0.13, but it is advised to use Python >=
+3.5.
 
 You can also clone the project on Github. The license of this record linkage
 package is BSD-3-Clause.

--- a/recordlinkage/algorithms/string.py
+++ b/recordlinkage/algorithms/string.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
-
 import warnings
 
 import jellyfish

--- a/recordlinkage/base.py
+++ b/recordlinkage/base.py
@@ -14,8 +14,6 @@ import numpy as np
 
 import pandas
 
-import six
-
 from recordlinkage import rl_logging as logging
 import recordlinkage.config as cf
 from recordlinkage.utils import (listify,
@@ -28,7 +26,6 @@ from recordlinkage.utils import (listify,
 from recordlinkage.types import (is_numpy_like,
                                  is_pandas_2d_multiindex)
 from recordlinkage.measures import max_pairs
-
 from recordlinkage.utils import DeprecationHelper, LearningError
 
 
@@ -874,7 +871,7 @@ class BaseCompare(object):
         raise AttributeError("this method was removed in version 0.12.0")
 
 
-class BaseClassifier(six.with_metaclass(ABCMeta)):
+class BaseClassifier(metaclass=ABCMeta):
     """Base class for classification of records pairs.
 
     This class contains methods for training the classifier.

--- a/recordlinkage/compare.py
+++ b/recordlinkage/compare.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
-
 from functools import partial
 
 import numpy

--- a/recordlinkage/datasets/external.py
+++ b/recordlinkage/datasets/external.py
@@ -1,10 +1,10 @@
+from io import BytesIO
 import os
+from urllib.request import urlopen
 import zipfile
 
 import pandas
 
-from six import BytesIO
-from six.moves.urllib.request import urlopen
 
 
 def load_krebsregister(block=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],

--- a/recordlinkage/datasets/external.py
+++ b/recordlinkage/datasets/external.py
@@ -1,5 +1,5 @@
 from io import BytesIO
-import os
+from pathlib import Path
 from urllib.request import urlopen
 import zipfile
 
@@ -68,10 +68,13 @@ def load_krebsregister(block=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
     # If the data is not found, download it.
     for i in range(1, 11):
 
-        filepath = os.path.join(os.path.dirname(__file__),
-                                'krebsregister', 'block_{}.zip'.format(i))
+        filepath = Path(
+            Path(__file__).parent,
+            'krebsregister', 
+            'block_{}.zip'.format(i)
+        )
 
-        if not os.path.exists(filepath):
+        if not filepath.is_file():
             _download_krebsregister()
             break
 
@@ -105,7 +108,7 @@ def _download_krebsregister():
 
         # unzip the content and put it in the krebsregister folder
         z = zipfile.ZipFile(BytesIO(r))
-        z.extractall(os.path.join(os.path.dirname(__file__), 'krebsregister'))
+        z.extractall(Path(Path(__file__).parent, 'krebsregister'))
 
         print("Data download succesfull.")
 
@@ -120,8 +123,11 @@ def _krebsregister_block(block):
             "Argument 'block' has to be integer in "
             "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10] or list of integers.")
 
-    fp_i = os.path.join(os.path.dirname(__file__),
-                        'krebsregister', 'block_{}.zip'.format(block))
+    fp_i = Path(
+        Path(__file__).parent,
+        'krebsregister', 
+        'block_{}.zip'.format(block)
+    )
 
     data_block = pandas.read_csv(
         fp_i,

--- a/recordlinkage/datasets/external.py
+++ b/recordlinkage/datasets/external.py
@@ -108,7 +108,7 @@ def _download_krebsregister():
 
         # unzip the content and put it in the krebsregister folder
         z = zipfile.ZipFile(BytesIO(r))
-        z.extractall(Path(Path(__file__).parent, 'krebsregister'))
+        z.extractall(str(Path(Path(__file__).parent, 'krebsregister')))
 
         print("Data download succesfull.")
 

--- a/recordlinkage/datasets/febrl.py
+++ b/recordlinkage/datasets/febrl.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pandas
 import numpy
 

--- a/recordlinkage/datasets/febrl.py
+++ b/recordlinkage/datasets/febrl.py
@@ -1,5 +1,3 @@
-import os
-
 import pandas
 import numpy
 
@@ -7,7 +5,11 @@ import numpy
 def _febrl_load_data(filename):
     # Internal function for loading febrl data
 
-    filepath = os.path.join(os.path.dirname(__file__), 'febrl', filename)
+    filepath = Path(
+        Path(__file__).parent,
+        'febrl', 
+        filename
+    )
 
     febrl_data = pandas.read_csv(filepath,
                                  index_col="rec_id",

--- a/recordlinkage/index.py
+++ b/recordlinkage/index.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import warnings
 
 import numpy

--- a/recordlinkage/measures.py
+++ b/recordlinkage/measures.py
@@ -1,7 +1,5 @@
 # measures.py
 
-from __future__ import division
-
 import numpy
 
 import pandas

--- a/recordlinkage/preprocessing/cleaning.py
+++ b/recordlinkage/preprocessing/cleaning.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import
-from __future__ import division
-# from __future__ import unicode_literals
-
 import sys
 
 from sklearn.feature_extraction.text import strip_accents_ascii, \

--- a/recordlinkage/types.py
+++ b/recordlinkage/types.py
@@ -14,9 +14,7 @@ import numpy
 
 import pandas
 
-from six import binary_type, string_types, text_type
-
-string_and_binary_types = (string_types,) + (binary_type,)
+string_and_binary_types = (str, bytes)
 
 
 def is_number(obj):
@@ -24,17 +22,16 @@ def is_number(obj):
 
 
 def is_string_like(obj):
-    return isinstance(obj, (text_type, string_types))
+    return isinstance(obj, str)
 
 
 def _iterable_not_string(x):
     return (isinstance(x, collections.Iterable) and
-            not isinstance(x, string_types))
+            not isinstance(x, str))
 
 
 def is_iterator(obj):
-    # python 3 generators have __next__ instead of next
-    return hasattr(obj, 'next') or hasattr(obj, '__next__')
+    return hasattr(obj, '__next__')
 
 
 def is_re(obj):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,4 @@
 
-[bdist_wheel]
-universal = 1
-
 [versioneer]
 VCS = git
 style = pep440

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
     url="https://github.com/J535D165/recordlinkage",
 
     install_requires=[
-        "six>=1.10.0",
         "jellyfish>=0.5.4",
         "numpy>=1.13.0",
         "pandas>=0.18.0",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 """Setup file for the Python Record Linkage Toolkit."""
 
-from pathlib import Path
+import os
 
 from setuptools import find_packages, setup
 
@@ -9,8 +9,7 @@ import versioneer
 
 def read(fname):
     """Read a file."""
-    fp = Path(Path(__file__).parent, fname)
-    return fp.read_text()
+    return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 
 setup(
@@ -29,7 +28,7 @@ setup(
     # Github
     url="https://github.com/J535D165/recordlinkage",
 
-    python_requires=">3.4",
+    python_requires=">=3.5",
     install_requires=[
         "jellyfish>=0.5.4",
         "numpy>=1.13.0",

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 """Setup file for the Python Record Linkage Toolkit."""
 
-import os
+from pathlib import Path
 
 from setuptools import find_packages, setup
 
@@ -9,7 +9,8 @@ import versioneer
 
 def read(fname):
     """Read a file."""
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    fp = Path(Path(__file__).parent, fname)
+    return open(fp).read()
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ import versioneer
 def read(fname):
     """Read a file."""
     fp = Path(Path(__file__).parent, fname)
-    return open(fp).read()
+    return fp.read_text()
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     # Github
     url="https://github.com/J535D165/recordlinkage",
 
+    python_requires=">3.4",
     install_requires=[
         "jellyfish>=0.5.4",
         "numpy>=1.13.0",

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function
-
 import os
 import tempfile
 import shutil

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36}-pandas{018,019,020,021,022,latest},flake8,docs
+envlist = py{35,36}-pandas{018,019,020,021,022,latest},flake8,docs
 
 [testenv]
 deps=


### PR DESCRIPTION
In this PR, we drop support for Python 2.7. This is in line with our dependencies like Jellyfish, Pandas and Numpy. 

Python 2.7 users can rely on recordlinkage version 0.13. From version 0.14 on, we support only Python >=3.5 (in line with Pandas).

