### PR TITLE
remove non binary columns, fixes #75

### DIFF
--- a/recordlinkage/algorithms/nb_sklearn.py
+++ b/recordlinkage/algorithms/nb_sklearn.py
@@ -11,6 +11,7 @@ module is based on scikit-learn's subdule :mod:`sklearn.naive_bayes`.
 # This module is based on sklearn's NB implementation. The license of sklearn
 # is BSD 3 clause. Modifications copyright Jonathan de Bruin.
 
+import sys
 import warnings
 
 import numpy as np
@@ -99,6 +100,24 @@ def safe_sparse_dot(a, b, dense_output=False):
         return ret
     else:
         return np.dot(a, b)
+
+
+def safe_log(x, offset=sys.float_info.min):
+    """Logarithm that handles small numbers by proving the smallest
+    offset possible. This maps log(0) from -inf to -708.39642.
+
+    Parameters
+    ----------
+    x : array or float
+    offset : float
+
+    Returns
+    -------
+    safe_log : logarithm base 10 that can handle small floats
+
+    """
+
+    return np.log(x + offset)
 
 
 def unique_rows_counts(a):
@@ -594,8 +613,8 @@ class ECM(BaseNB):
 
             # maximisation step
             class_log_prior_ = np.log(g_freq_sum) - np.log(X.shape[0])  # p
-            feature_log_prob_ = np.log(safe_sparse_dot(g_freq.T, X_unique_bin))
-            feature_log_prob_ -= np.log(np.atleast_2d(g_freq_sum).T)
+            feature_log_prob_ = safe_log(safe_sparse_dot(g_freq.T, X_unique_bin))
+            feature_log_prob_ -= safe_log(np.atleast_2d(g_freq_sum).T)
 
             # Stop iterating when the class prior and feature probs are close
             # to the values in the to previous iteration (parameters starting


### PR DESCRIPTION
#75 is an issue where the `ECMClassifier` would give an error such as

```
ValueError: could not broadcast input array from shape (16) into shape (17)
```

This happens because the code assumes all feature columns to be binary, i.e. contain both `0`'s and `1`'s. If for some reason one columns only contains one of those, the binarization step will only create 1 column instead of 2. The final numpy array has an odd number of columns, which causes the error in the following lines

```
feature_prob[0, :] = np.tile([.9, .1], int(n_features / 2))
feature_prob[1, :] = np.tile([.1, .9], int(n_features / 2))
```

in `_init_parameters_jaro` which is the standard method.

The fix is a simple function `_remove_non_binary` that removes any column of the numpy array that only has a single value after binarization. This function is called in both `_fit_data` and `_transform_data`. As such, the user does not need to worry about the features. Since this function is called in these two functions, there is no need to binarize the input in both of these seperately.