### PR TITLE
correctly parse n_jobs=-1 (#96)

### DIFF
--- a/recordlinkage/base.py
+++ b/recordlinkage/base.py
@@ -8,7 +8,7 @@ import time
 import warnings
 from abc import ABCMeta, abstractmethod
 
-from joblib import Parallel, delayed
+from joblib import Parallel, delayed, cpu_count
 
 import numpy as np
 
@@ -538,7 +538,10 @@ class BaseCompare(object):
         self.add(features)
 
         # public
-        self.n_jobs = n_jobs
+        if n_jobs == -1:
+            self.n_jobs = cpu_count()
+        else:
+            self.n_jobs = n_jobs
         self.indexing_type = indexing_type  # label of position
         self.features = []
 


### PR DESCRIPTION
`index_split` can not parse `n_jobs = -1`. A solution is to pass the actual maximum number of cpu cores instead, as provided by `joblib.cpu_count`