### PR TITLE
Compat: pandas MultiIndex .labels to .codes

### DIFF
--- a/recordlinkage/base.py
+++ b/recordlinkage/base.py
@@ -285,7 +285,11 @@ class BaseIndexAlgorithm(object):
         # Remove all pairs not in the lower triangular part of the matrix.
         # This part can be inproved by not comparing the level values, but the
         # level itself.
-        pairs = pairs[pairs.labels[0] > pairs.labels[1]]
+        try:
+            pairs = pairs[pairs.codes[0] > pairs.codes[1]]
+        except AttributeError:
+            # backwards compat pandas <24
+            pairs = pairs[pairs.labels[0] > pairs.labels[1]] 
 
         return pairs
 

--- a/recordlinkage/utils.py
+++ b/recordlinkage/utils.py
@@ -1,5 +1,6 @@
 import warnings
 from functools import wraps
+from packaging import version
 
 import numpy
 
@@ -76,6 +77,10 @@ def return_type_deprecator(func):
 
 
 # Checks and conversions
+
+def is_min_pandas_version(min_version):
+    """Check if pandas version is larger or equal the version passed."""
+    return version.parse(pandas.__version__) >= version.parse(min_version)
 
 
 def is_label_dataframe(label, df):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -10,6 +10,7 @@ import pytest
 
 import recordlinkage as rl
 from recordlinkage import index_split
+from recordlinkage.utils import is_min_pandas_version
 
 
 def test_multiindex_split():
@@ -24,7 +25,10 @@ def test_multiindex_split():
         ptm.assert_index_equal(result_index_chunk, expected_index_chunk)
 
         assert len(result_index_chunk.levels) == 2
-        assert len(result_index_chunk.labels) == 2
+        if is_min_pandas_version("0.24.0"):
+            assert len(result_index_chunk.codes) == 2
+        else:
+            assert len(result_index_chunk.labels) == 2
 
 
 def test_options():


### PR DESCRIPTION
Change `pandas.MultiIndex.labels` into `pandas.MultiIndex.codes` with backwards compatibility. This removes the future/deprecation warning

Closes #99 