### PR TITLE
fix accuracy for pandas.MultiIndex fixes #84

### DIFF
--- a/recordlinkage/measures.py
+++ b/recordlinkage/measures.py
@@ -384,6 +384,9 @@ def accuracy(links_true, links_pred=None, total=None):
         The accuracy
     """
 
+    if isinstance(total, pandas.MultiIndex):
+        total = len(total)
+
     if _isconfusionmatrix(links_true):
 
         confusion_matrix = links_true

--- a/recordlinkage/measures.py
+++ b/recordlinkage/measures.py
@@ -286,6 +286,9 @@ def confusion_matrix(links_true, links_pred, total=None):
     if total is None:
         tn = numpy.nan
     else:
+        
+        if isinstance(total, pandas.MultiIndex):
+            total = len(total)
         tn = true_negatives(links_true, links_pred, total)
 
     return numpy.array([[tp, fn], [fp, tn]])
@@ -436,6 +439,9 @@ def specificity(links_true, links_pred=None, total=None):
     else:
 
         fp = false_positives(links_true, links_pred)
+
+        if isinstance(total, pandas.MultiIndex):
+            total = len(total)
         tn = true_negatives(links_true, links_pred, total)
         v = tn / (fp + tn)
 

--- a/tests/test_measures.py
+++ b/tests/test_measures.py
@@ -61,6 +61,7 @@ class TestMeasures(object):
 
         assert rl.accuracy(LINKS_TRUE, LINKS_PRED, len(FULL_INDEX)) == 4 / 9
         assert rl.accuracy(cm) == 4 / 9
+        assert rl.accuracy(LINKS_TRUE, LINKS_PRED, FULL_INDEX) == 4 / 9
 
     def test_specificity(self):
 

--- a/tests/test_measures.py
+++ b/tests/test_measures.py
@@ -22,10 +22,12 @@ LINKS_PRED = pandas.MultiIndex.from_tuples(
 class TestMeasures(object):
     def test_confusion_matrix(self):
 
-        result = rl.confusion_matrix(LINKS_TRUE, LINKS_PRED, len(FULL_INDEX))
+        result_len = rl.confusion_matrix(LINKS_TRUE, LINKS_PRED, len(FULL_INDEX))
+        result_full_index = rl.confusion_matrix(LINKS_TRUE, LINKS_PRED, FULL_INDEX)
         expected = numpy.array([[1, 2], [3, 3]])
 
-        numpy.testing.assert_array_equal(result, expected)
+        numpy.testing.assert_array_equal(result_len, expected)
+        numpy.testing.assert_array_equal(result_full_index, expected)
 
     def test_tp_fp_tn_fn(self):
 
@@ -70,6 +72,7 @@ class TestMeasures(object):
 
         assert rl.specificity(LINKS_TRUE, LINKS_PRED, len(FULL_INDEX)) == 1 / 2
         assert rl.specificity(cm) == 1 / 2
+        assert rl.specificity(LINKS_TRUE, LINKS_PRED, FULL_INDEX) == 1 / 2
 
     def test_fscore(self):
 


### PR DESCRIPTION
This fix allow the accuracy function to accept a pandas.MultiIndex as mentioned in the docs i.e (When the argument is a pandas.MultiIndex, the length of the index is used)