### PR TITLE
fixed typo in ref-index.rst

### DIFF
--- a/docs/ref-index.rst
+++ b/docs/ref-index.rst
@@ -106,7 +106,7 @@ Examples
     indexer = rl.Index()
     indexer.add(Block('given_name', 'given_name'))
     indexer.add(Block('surname', 'surname'))
-    index.index(df_a, df_b)
+    indexer.index(df_a, df_b)
 
 Equivalent code:
 


### PR DESCRIPTION
I was following the tutorial and I found a mistake in ref-index.rst. Instead of index.index it should be indexer.index