### PR TITLE
Fix bugs for cosine and qgram string comparisons

### DIFF
--- a/recordlinkage/compare.py
+++ b/recordlinkage/compare.py
@@ -150,6 +150,8 @@ class String(BaseCompareFeature):
         c = str_sim_alg(s_left, s_right)
 
         if self.threshold is not None:
+            if isinstance(c, pandas.Series) is False:
+                c = pandas.Series(c)
             c = c.where((c < self.threshold) | (pandas.isnull(c)), other=1.0)
             c = c.where((c >= self.threshold) | (pandas.isnull(c)), other=0.0)
 

--- a/recordlinkage/compare.py
+++ b/recordlinkage/compare.py
@@ -150,7 +150,7 @@ class String(BaseCompareFeature):
         c = str_sim_alg(s_left, s_right)
 
         if self.threshold is not None:
-            if isinstance(c, pandas.Series) is False:
+            if not isinstance(c, pandas.Series):
                 c = pandas.Series(c)
             c = c.where((c < self.threshold) | (pandas.isnull(c)), other=1.0)
             c = c.where((c >= self.threshold) | (pandas.isnull(c)), other=0.0)

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1234,6 +1234,22 @@ class TestCompareStrings(TestData):
             missing_value=nan,
             label="x_col3"
         )
+        comp.string(
+            'col',
+            'col',
+            method="cosine",
+            threshold=0.5,
+            missing_value=nan,
+            label="x_col4"
+        )
+        comp.string(
+            'col',
+            'col',
+            method="q_gram",
+            threshold=0.5,
+            missing_value=nan,
+            label="x_col5"
+        )
         result = comp.compute(ix, A, B)
 
         expected = Series([1.0, 1.0, 2.0, 0.0], index=ix, name="x_col1")
@@ -1244,6 +1260,12 @@ class TestCompareStrings(TestData):
 
         expected = Series([1.0, 1.0, nan, 1.0], index=ix, name="x_col3")
         pdt.assert_series_equal(result["x_col3"], expected)
+
+        expected = Series([1.0, 1.0, nan, 0.0], index=ix, name="x_col4")
+        pdt.assert_series_equal(result["x_col4"], expected)
+
+        expected = Series([1.0, 1.0, 0.0, 0.0], index=ix, name="x_col5")
+        pdt.assert_series_equal(result["x_col5"], expected)
 
     @pytest.mark.parametrize("alg", STRING_SIM_ALGORITHMS)
     def test_incorrect_input(self, alg):


### PR DESCRIPTION
String comparisons with a threshold did not work for the `cosine` and `qgram` algorithms. 
This was because the output of these algorithms was numpy arrays whereas the comparison method was expecting pandas Series. 

This PR fixes this and also updates the tests. 