### PR TITLE
Removed unnecessary np.sort from the _get_sorting_key_values in SNI

### DIFF
--- a/recordlinkage/index.py
+++ b/recordlinkage/index.py
@@ -256,9 +256,7 @@ class SortedNeighbourhood(BaseIndexAlgorithm):
         """return the sorting key values as a series"""
 
         concat_arrays = numpy.concatenate([array1, array2])
-        unique_values = numpy.unique(concat_arrays)
-
-        return numpy.sort(unique_values)
+        return numpy.unique(concat_arrays)  # numpy.unique returns sorted list
 
     def _link_index(self, df_a, df_b):
 

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -589,6 +589,14 @@ class TestSortedNeighbourhoodIndexing(TestData):
 
         pdt.assert_index_equal(pairs_new, pairs_old)
 
+    def test_get_sorting_key_values(self):
+        index_class = SortedNeighbourhood()
+        array1 = [10, 1, 2, 1, 2, 1, 9, 8]
+        array2 = [5, 5, 5, 3, 1, 4, 7, 10]
+        res = index_class._get_sorting_key_values(array1, array2)
+        res_sorted = np.sort(res)
+        np.testing.assert_array_equal(res, res_sorted)
+
 
 class TestRandomIndexing(TestData):
     """General unittest for the random indexing class."""


### PR DESCRIPTION
In function _get_sorting_key_values from SortedNeighbourhood you don't need to run np.sort function since np.unique returns already sorted list (https://numpy.org/doc/stable/reference/generated/numpy.unique.html).

This gives some speed up in my applications (default algo for numpy is quicksort and it requires substantial amount of time even for already sorted data).