### PR TITLE
Fix random indexer

### DIFF
--- a/recordlinkage/algorithms/indexing.py
+++ b/recordlinkage/algorithms/indexing.py
@@ -29,7 +29,7 @@ def random_pairs_with_replacement(n, shape, random_state=None):
         raise ValueError('n_max must be larger than 0')
 
     # make random pairs
-    indices = random_state.randint(0, n_max, n)
+    indices = random_state.randint(0, n_max, n, dtype=np.int64)
 
     if len(shape) == 1:
         return _map_tril_1d_on_2d(indices, shape[0])

--- a/recordlinkage/api.py
+++ b/recordlinkage/api.py
@@ -82,7 +82,7 @@ class Index(BaseIndex):
             indexer.add(Random())
 
         """
-        indexer = Random()
+        indexer = Random(*args, **kwargs)
         self.add(indexer)
 
         return self


### PR DESCRIPTION
I changed the dtype for the random indexer to `np.int64` since it wasn't working with the defaults (for me).

Also, the `indexer.random` method was missing arguments.