### PR TITLE
Remove deprecated recordlinkage classes 

### DIFF
--- a/recordlinkage/__init__.py
+++ b/recordlinkage/__init__.py
@@ -13,11 +13,6 @@ from recordlinkage.config import option_context
 from recordlinkage.config import options
 from recordlinkage.config import reset_option
 from recordlinkage.config import set_option
-from recordlinkage.deprecated import *
-from recordlinkage.index import BlockIndex
-from recordlinkage.index import FullIndex
-from recordlinkage.index import RandomIndex
-from recordlinkage.index import SortedNeighbourhoodIndex
 from recordlinkage.measures import *
 from recordlinkage.network import *
 from recordlinkage.utils import index_split

--- a/recordlinkage/base.py
+++ b/recordlinkage/base.py
@@ -285,13 +285,7 @@ class BaseIndexAlgorithm(object):
         # Remove all pairs not in the lower triangular part of the matrix.
         # This part can be inproved by not comparing the level values, but the
         # level itself.
-        try:
-            pairs = pairs[pairs.codes[0] > pairs.codes[1]]
-        except AttributeError:
-            # backwards compat pandas <24
-            pairs = pairs[pairs.labels[0] > pairs.labels[1]]
-
-        return pairs
+        return pairs[pairs.codes[0] > pairs.codes[1]]
 
     def _make_index_names(self, name1, name2):
 

--- a/recordlinkage/deprecated.py
+++ b/recordlinkage/deprecated.py
@@ -1,12 +1,1 @@
-class PairsCore(object):
-
-    def __init__(self, *args, **kwargs):
-
-        raise AttributeError("this class was removed in version 0.12.0")
-
-
-class Pairs(object):
-
-    def __init__(self, *args, **kwargs):
-
-        raise AttributeError("this class was removed in version 0.12.0")
+"""Home of all deprecated functions and classes."""

--- a/recordlinkage/index.py
+++ b/recordlinkage/index.py
@@ -465,17 +465,3 @@ class Random(BaseIndexAlgorithm):
         return pandas.MultiIndex(levels=levels,
                                  codes=labels,
                                  verify_integrity=False)
-
-
-FullIndex = DeprecationHelper(
-    Full, "class recordlinkage.FullIndex is renamed and moved, "
-    "use recordlinkage.index.Full")
-BlockIndex = DeprecationHelper(
-    Block, "class recordlinkage.BlockIndex is renamed and moved, "
-    "use recordlinkage.index.Block")
-SortedNeighbourhoodIndex = DeprecationHelper(
-    SortedNeighbourhood, "class recordlinkage.SortedNeighbourhoodIndex "
-    "is renamed and moved, use recordlinkage.index.SortedNeighbourhood")
-RandomIndex = DeprecationHelper(
-    Random, "class recordlinkage.RandomIndex is renamed and moved, "
-    "use recordlinkage.index.Random")


### PR DESCRIPTION
This removes:

```python
from recordlinkage import BlockIndex
from recordlinkage import FullIndex
from recordlinkage import RandomIndex
from recordlinkage import SortedNeighbourhoodIndex
from recordlinkage.index import BlockIndex
from recordlinkage.index import FullIndex
from recordlinkage.index import RandomIndex
from recordlinkage.index import SortedNeighbourhoodIndex
from recordlinkage import PairsCore
from recordlinkage import Pairs
```