### PR TITLE
add threshold None and label docstrings for String

### DIFF
--- a/recordlinkage/compare.py
+++ b/recordlinkage/compare.py
@@ -99,11 +99,15 @@ class String(BaseCompareFeature):
         An approximate string comparison method. Options are ['jaro',
         'jarowinkler', 'levenshtein', 'damerau_levenshtein', 'qgram',
         'cosine', 'smith_waterman', 'lcs']. Default: 'levenshtein'
-    threshold : float, tuple of floats
+    threshold : None, float, tuple of floats
         A threshold value. All approximate string comparisons higher or
         equal than this threshold are 1. Otherwise 0.
+        If None, it returns the float string comparison value instead of 0 or 1.
+        Default None.
     missing_value : numpy.dtype
         The value for a comparison with a missing value. Default 0.
+    label : list, str, int
+        The identifying label(s) for the returned values. Default None.
     """
 
     name = "string"


### PR DESCRIPTION
When using String comparins, it is not evident in the docstring that you don't need to set a threshold. 
The default value is None, and in case of using it you receibe the float number math metric instead of a 0/1 value.
This is stated in the docstring.

Also, `label` input was not explained in the docstring. So it has been added.